### PR TITLE
build: install bpftool for github runner

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,6 +1,11 @@
 ---
 name: Build and Push Containers
 
+## Notes
+# Building SeaBee requires vmlinux for your kernel
+# vmlinux.h requires bpftool, which is also kernel specific
+# This means that the container must be build on the same system that is going to run them in order to build correctly
+
 on:
   schedule:
     - cron: '11 11 * * 6'  # Choosing an random non-peak time: every Saturday at 11:11 UTC

--- a/scripts/update_root_dependencies.sh
+++ b/scripts/update_root_dependencies.sh
@@ -58,6 +58,10 @@ install_system_packages() {
     apt install --no-install-recommends -y \
       "${common_deps[@]}" \
       "${library_deps_deb[@]}"
+    # Dependencies needed for github ci runners
+    if [ "$DOCKER" -eq 1 ]; then
+      apt install --no-install-recommends -y linux-tools-azure linux-cloud-tools-azure
+    fi
   elif [ $USE_DNF -eq 1 ]; then
     dnf update -y
     dnf install -y \


### PR DESCRIPTION
container build is failing becuase bpftool is installed for container OS rather than host OS in github runner. This commit should fix that by installing bpftool for the github runner.