### PR TITLE
build: add specific packages for github ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -20,7 +20,8 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # changing the runner will break the build
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     container:
       image: ghcr.io/nationalsecurityagency/seabee-build-ubuntu-jammy


### PR DESCRIPTION
bpftool needs a particular kernel version in order to run. bpftool is needed to generate vmlinux on the build machine. This commit ensures that github ubuntu-24.04 runner will have the right bpftool version.

This approach is more flexible than changing the dockerfile or github actions file to get the host bpftool version.