### PR TITLE
2 add ptrace to seabee policy

### DIFF
--- a/bpf/include/logging_types.h
+++ b/bpf/include/logging_types.h
@@ -163,6 +163,8 @@ struct ptrace_access_check_log {
 	struct log_hdr header;
 	/// @brief The process ID to be traced
 	int            target_pid;
+	/// @brief The ptrace mode used
+	unsigned int   mode;
 	/// @brief same as /proc/{pid}/comm for traced process
 	unsigned char  target_comm[COMM_LEN];
 };

--- a/bpf/include/shared_rust_types.h
+++ b/bpf/include/shared_rust_types.h
@@ -30,12 +30,15 @@ enum SecurityLevel {
  * by the rust bindings we generate based on this code.
  */
 struct c_policy_config {
-	unsigned long long sigmask;           // 8
-	unsigned char      signals;           // 1
-	unsigned char      file_modification; // 1
+	unsigned long long signal_allow_mask; // 8
+	unsigned char      signal_access;     // 1
+	unsigned char      ptrace_access;     // 1
+	unsigned char      file_write_access; // 1
 	unsigned char      map_access;        // 1
-	unsigned char      pin_removal;       // 1
-	unsigned int       padding;           // 4
+	unsigned char      pin_access;        // 1
+	unsigned char      padding_1;         // 3
+	unsigned char      padding_2;
+	unsigned char      padding_3;
 };
 
 #endif

--- a/bpf/include/shared_rust_types.h
+++ b/bpf/include/shared_rust_types.h
@@ -6,7 +6,6 @@
  *
  * shared types for which rust bindings are generated
  */
-
 #include "constants.h"
 
 /**

--- a/bpf/src/logging/mod.rs
+++ b/bpf/src/logging/mod.rs
@@ -299,7 +299,11 @@ impl std::fmt::Display for kernel_load_data_log {
 impl std::fmt::Display for ptrace_access_check_log {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let target_comm = char_array_to_str(&self.target_comm);
-        write!(f, "ptrace {}({})", target_comm, self.target_pid)
+        write!(
+            f,
+            "ptrace mode {} on {}({})",
+            self.mode, target_comm, self.target_pid
+        )
     }
 }
 

--- a/bpf/src/seabee/seabee.bpf.c
+++ b/bpf/src/seabee/seabee.bpf.c
@@ -500,7 +500,7 @@ int BPF_PROG(seabee_kernel_load_data, enum kernel_load_data_id id,
  * because it is only invoked by the child process.
  *
  * @param child the process that is going to be traced (tracee)
- * @param mode PTRACE_MODE flags
+ * @param mode PTRACE_MODE flags, see linux/ptrace.h
  * @param ret the return code of the previous LSM hook
  *
  * @return {@link ALLOW} or {@link DENY}
@@ -525,12 +525,12 @@ int BPF_PROG(seabee_ptrace_access_check, struct task_struct *child,
 			return ALLOW;
 		case SECURITY_AUDIT:
 			log_ptrace_access_check(LOG_LEVEL_INFO, LOG_REASON_AUDIT, child,
-			                        tracee_label);
+			                        mode, tracee_label);
 			return ALLOW;
 		case SECURITY_BLOCK:
 			// info level because this hook generates a lot of noise
 			log_ptrace_access_check(LOG_LEVEL_INFO, LOG_REASON_DENY, child,
-			                        tracee_label);
+			                        mode, tracee_label);
 			return DENY;
 		default: {
 			u64 data[] = { level };

--- a/bpf/src/seabee/seabee_log.h
+++ b/bpf/src/seabee/seabee_log.h
@@ -87,14 +87,15 @@ static inline void log_kernel_load_data(enum LogLevel  level,
 
 static inline void log_ptrace_access_check(enum LogLevel       level,
                                            enum LogReason      reason,
-                                           struct task_struct *tracee,
-                                           u32                 pol_id)
+                                           struct task_struct *tracee, u32 mode,
+                                           u32 pol_id)
 {
 	struct ptrace_access_check_log *log;
 	log = log_buf(level, reason, EVENT_TYPE_PTRACE_ACCESS_CHECK, sizeof(*log),
 	              pol_id);
 	if (log) {
 		log->target_pid = tracee->tgid;
+		log->mode       = mode;
 		bpf_probe_read_str(log->target_comm, sizeof(log->target_comm),
 		                   tracee->comm);
 		bpf_ringbuf_submit(log, 0);

--- a/bpf/src/seabee/seabee_log.h
+++ b/bpf/src/seabee/seabee_log.h
@@ -85,17 +85,18 @@ static inline void log_kernel_load_data(enum LogLevel  level,
 	}
 }
 
-static inline void log_ptrace_access_check(enum LogLevel  level,
-                                           enum LogReason reason,
-                                           int target_pid, char *target_comm)
+static inline void log_ptrace_access_check(enum LogLevel       level,
+                                           enum LogReason      reason,
+                                           struct task_struct *tracee,
+                                           u32                 pol_id)
 {
 	struct ptrace_access_check_log *log;
 	log = log_buf(level, reason, EVENT_TYPE_PTRACE_ACCESS_CHECK, sizeof(*log),
-	              NO_POL_ID);
+	              pol_id);
 	if (log) {
-		log->target_pid = target_pid;
+		log->target_pid = tracee->tgid;
 		bpf_probe_read_str(log->target_comm, sizeof(log->target_comm),
-		                   target_comm);
+		                   tracee->comm);
 		bpf_ringbuf_submit(log, 0);
 	}
 }

--- a/seabee/src/cli.rs
+++ b/seabee/src/cli.rs
@@ -173,7 +173,6 @@ impl From<Args> for crate::config::Config {
             log_level: args.log_level.unwrap().into(),
             sigint: args.sigint.unwrap(),
             kmod: args.kmod.unwrap(),
-            ptrace: args.ptrace.unwrap(),
             log_filter: {
                 let mut filter = HashSet::new();
                 for log_type in &args.exclude {
@@ -198,7 +197,8 @@ impl From<Args> for PolicyConfig {
             map_access: args.map_modification.unwrap(),
             pin_access: args.pin_modification.unwrap(),
             file_write_access: args.daemon_modification.unwrap(),
-            signals: SecurityLevel::block,
+            ptrace_access: args.ptrace.unwrap(),
+            signal_access: SecurityLevel::block,
             signal_allow_mask: utils::generate_sigmask(args.sigint.unwrap()),
         }
     }

--- a/seabee/src/config.rs
+++ b/seabee/src/config.rs
@@ -56,10 +56,7 @@ pub fn configure_logging(log_level: LogLevel) -> Result<()> {
                 .without_time()
                 .with_filter(filter),
         );
-        match tracing_journald::layer() {
-            Ok(layer) => registry.with(layer).init(),
-            Err(_) => tracing::error!("Unable to connect to journald"),
-        };
+        registry.init();
     });
 
     Ok(())

--- a/seabee/src/config.rs
+++ b/seabee/src/config.rs
@@ -93,7 +93,6 @@ pub struct Config {
     pub log_level: LogLevel,
     pub sigint: SecurityLevel,
     pub kmod: SecurityLevel,
-    pub ptrace: SecurityLevel,
     pub policy_config: PolicyConfig,
     pub log_filter: HashSet<EventType>,
     // will only be true during test cases
@@ -111,7 +110,6 @@ impl Default for Config {
             log_level: LogLevel::LOG_LEVEL_INFO,
             sigint: SecurityLevel::block,
             kmod: SecurityLevel::audit,
-            ptrace: SecurityLevel::block,
             policy_config: Default::default(),
             test: false,
             log_filter: HashSet::new(),

--- a/seabee/src/policy/fs_api.rs
+++ b/seabee/src/policy/fs_api.rs
@@ -119,6 +119,9 @@ pub fn save_seabee_file_and_sig(
     // save file if it doesn't already exist
     // make sure that source and dest for copy are different
     if dest_path != src_path {
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
         if let Err(e) = fs::copy(src_path, dest_path) {
             return Err(anyhow!(
                 "add_new_policy_from_yaml: failed to copy from {} to {}. Got error: {e}",
@@ -131,6 +134,9 @@ pub fn save_seabee_file_and_sig(
     // make sure that source and dest for copy are different
     if let Some(sig_path) = sig_path {
         if *sig_path != new_sig_path {
+            if let Some(parent) = new_sig_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
             if let Err(e) = fs::copy(sig_path, &new_sig_path) {
                 return Err(anyhow!(
                     "add_new_policy_from_yaml: failed to copy from {} to {}. Got error: {e}",

--- a/seabee/src/policy/policy_file.rs
+++ b/seabee/src/policy/policy_file.rs
@@ -19,6 +19,7 @@ pub const BASE_POLICY_ID: u32 = bpf::seabee::BASE_POLICY_ID;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 #[serde_as]
 pub struct PolicyConfig {
     /// Select map security level
@@ -55,12 +56,12 @@ impl Default for PolicyConfig {
 impl PolicyConfig {
     pub fn to_c_policy_config(&self) -> bpf::seabee::c_policy_config {
         bpf::seabee::c_policy_config {
+            signal_allow_mask: self.signal_allow_mask,
+            signal_access: self.signal_access as u8,
+            ptrace_access: self.ptrace_access as u8,
             file_write_access: self.file_write_access as u8,
             map_access: self.map_access as u8,
             pin_access: self.pin_access as u8,
-            ptrace_access: self.ptrace_access as u8,
-            signal_access: self.signal_access as u8,
-            signal_allow_mask: self.signal_allow_mask,
             padding_1: 0,
             padding_2: 0,
             padding_3: 0,
@@ -141,8 +142,8 @@ impl std::fmt::Display for PolicyFile {
         };
         write!(
             f,
-            "{}: {}\n  signed by key id: {}\n  version: {}\n  scope: {}\n  files: {}\n  config:\n    maps: {}\n    pins: {}\n    files: {}",
-            self.id, self.name, key_id_str, self.version, self.scope.iter().join(", "), self.files.iter().join(", "), self.config.map_access, self.config.pin_access, self.config.file_write_access,
+            "{}: {}\n  signed by key id: {}\n  version: {}\n  scope: {}\n  files: {}\n  config:\n    maps: {}\n    pins: {}\n    files: {}\n    ptrace: {}\n    signals: {}\n    signal allow mask: {}",
+            self.id, self.name, key_id_str, self.version, self.scope.iter().join(", "), self.files.iter().join(", "), self.config.map_access, self.config.pin_access, self.config.file_write_access, self.config.ptrace_access, self.config.signal_access, self.config.signal_allow_mask
         )
     }
 }

--- a/seabee/src/policy/policy_file.rs
+++ b/seabee/src/policy/policy_file.rs
@@ -25,10 +25,12 @@ pub struct PolicyConfig {
     pub map_access: SecurityLevel,
     /// Select pin security level
     pub pin_access: SecurityLevel,
-    /// Protection level for files
+    /// Determines how to protect files in scope
     pub file_write_access: SecurityLevel,
+    /// Determines if how ptrace can be used on processes in scope
+    pub ptrace_access: SecurityLevel,
     /// Determines how to apply signal mask
-    pub signals: SecurityLevel,
+    pub signal_access: SecurityLevel,
     /// Determines which signals should be allowed
     #[serde_as(as = "DisplayFromStr")] // allows hex formatting
     pub signal_allow_mask: u64,
@@ -42,7 +44,8 @@ impl Default for PolicyConfig {
             map_access: SecurityLevel::block,
             pin_access: SecurityLevel::block,
             file_write_access: SecurityLevel::block,
-            signals: SecurityLevel::block,
+            ptrace_access: SecurityLevel::block,
+            signal_access: SecurityLevel::block,
             // generate a sigmask for all signals that can kill a process
             signal_allow_mask: utils::generate_sigmask(SecurityLevel::block),
         }
@@ -52,12 +55,15 @@ impl Default for PolicyConfig {
 impl PolicyConfig {
     pub fn to_c_policy_config(&self) -> bpf::seabee::c_policy_config {
         bpf::seabee::c_policy_config {
-            file_modification: self.file_write_access as u8,
+            file_write_access: self.file_write_access as u8,
             map_access: self.map_access as u8,
-            pin_removal: self.pin_access as u8,
-            signals: self.signals as u8,
-            sigmask: self.signal_allow_mask,
-            padding: 0,
+            pin_access: self.pin_access as u8,
+            ptrace_access: self.ptrace_access as u8,
+            signal_access: self.signal_access as u8,
+            signal_allow_mask: self.signal_allow_mask,
+            padding_1: 0,
+            padding_2: 0,
+            padding_3: 0,
         }
     }
 }

--- a/tests/crypto/gen_sigs.sh
+++ b/tests/crypto/gen_sigs.sh
@@ -22,8 +22,11 @@ sudo seabeectl sign -t policies/test_policy_sha256.yaml -k crypto/keys/ecdsa-pri
 sudo seabeectl sign -t policies/test_policy_sha256.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-policy-rsa-sha256.sign --nopass
 
 ## test policy
-sudo seabeectl sign -t policies/test_tool_debug_policy.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-debug-policy.sign --nopass
-sudo seabeectl sign -t policies/test_tool_release_policy.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-release-policy.sign --nopass
+sudo seabeectl sign -t policies/test_tool_debug_audit.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-debug-audit.sign --nopass
+sudo seabeectl sign -t policies/test_tool_release_audit.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-release-audit.sign --nopass
+sudo seabeectl sign -t policies/test_tool_debug_block.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-debug-block.sign --nopass
+sudo seabeectl sign -t policies/test_tool_release_block.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/test-tool-release-block.sign --nopass
+sudo seabeectl sign -t policies/remove_test_tool_policy.yaml -k crypto/keys/rsa-private.pem -o crypto/sigs/remove-test-tool-policy.sign --nopass
 
 ## policy removal
 sudo seabeectl sign -t policies/remove_test_policy.yaml -k crypto/keys/ecdsa-private.pem -o crypto/sigs/remove-test-policy-ecdsa.sign --nopass

--- a/tests/policies/remove_test_tool_policy.yaml
+++ b/tests/policies/remove_test_tool_policy.yaml
@@ -1,0 +1,3 @@
+---
+name: test-tool-policy
+version: 1

--- a/tests/policies/test_tool_debug_audit.yaml
+++ b/tests/policies/test_tool_debug_audit.yaml
@@ -1,0 +1,12 @@
+---
+name: test-tool-policy
+version: 1
+scope:
+  - ../target/debug/test_tool
+files:
+config:
+  map_access: audit
+  file_write_access: audit
+  pin_access: audit
+  ptrace_access: audit
+  signal_access: audit

--- a/tests/policies/test_tool_debug_block.yaml
+++ b/tests/policies/test_tool_debug_block.yaml
@@ -8,5 +8,6 @@ config:
   map_access: block
   file_write_access: block
   pin_access: block
-  signals: block
+  ptrace_access: block
+  signal_access: block
   signal_allow_mask: 0x8430002

--- a/tests/policies/test_tool_release_audit.yaml
+++ b/tests/policies/test_tool_release_audit.yaml
@@ -1,0 +1,12 @@
+---
+name: test-tool-policy
+version: 1
+scope:
+  - ../target/release/test_tool
+files:
+config:
+  map_access: audit
+  file_write_access: audit
+  pin_access: audit
+  ptrace_access: audit
+  signal_access: audit

--- a/tests/policies/test_tool_release_block.yaml
+++ b/tests/policies/test_tool_release_block.yaml
@@ -8,5 +8,6 @@ config:
   map_access: block
   file_write_access: block
   pin_access: block
-  signals: block
+  ptrace_access: block
+  signal_access: block
   signal_allow_mask: 0x8430002

--- a/tests/src/policy/protect_tool.rs
+++ b/tests/src/policy/protect_tool.rs
@@ -1,50 +1,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::{Child, Command};
+use std::{
+    process::{Child, Command},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        OnceLock,
+    },
+};
 
 use anyhow::{anyhow, Result};
 use libtest_mimic::{Failed, Trial};
-use seabee::{constants::SEABEECTL_EXE, utils};
+use seabee::{config::SecurityLevel, constants::SEABEECTL_EXE, utils};
 use serde::Deserialize;
 
 use crate::{command::TestCommandBuilder, create_test, test_utils};
 
-use super::{shared::RSA_PUB, TEST_TOOL_PID};
+use super::shared::{RSA_PUB, RSA_PUB_ROOT_SIG};
+
+// Globals
+pub static TEST_TOOL_PID: OnceLock<AtomicU32> = OnceLock::new();
+pub const REMOVE_TEST_TOOL_POLICY: &str = "policies/remove_test_tool_policy.yaml";
+pub const REMOVE_TEST_TOOL_POLICY_SIG: &str = "crypto/sigs/remove-test-tool-policy.sign";
 
 // use debug policy for debug build
 #[cfg(debug_assertions)]
 mod test_tool_config {
     pub const TEST_TOOL_BIN: &str = "../target/debug/test_tool";
-    pub const TEST_TOOL_POLICY: &str = "policies/test_tool_debug_policy.yaml";
-    pub const TEST_TOOL_POLICY_SIG: &str = "crypto/sigs/test-tool-debug-policy.sign";
+    pub const TEST_TOOL_AUDIT_POLICY: &str = "policies/test_tool_debug_audit.yaml";
+    pub const TEST_TOOL_AUDIT_POLICY_SIG: &str = "crypto/sigs/test-tool-debug-audit.sign";
+    pub const TEST_TOOL_BLOCK_POLICY: &str = "policies/test_tool_debug_block.yaml";
+    pub const TEST_TOOL_BLOCK_POLICY_SIG: &str = "crypto/sigs/test-tool-debug-block.sign";
 }
 
 // use release policy for release build
 #[cfg(not(debug_assertions))]
 mod test_tool_config {
     pub const TEST_TOOL_BIN: &str = "../target/release/test_tool";
-    pub const TEST_TOOL_POLICY: &str = "policies/test_tool_release_policy.yaml";
-    pub const TEST_TOOL_POLICY_SIG: &str = "crypto/sigs/test-tool-release-policy.sign";
+    pub const TEST_TOOL_AUDIT_POLICY: &str = "policies/test_tool_release_audit.yaml";
+    pub const TEST_TOOL_AUDIT_POLICY_SIG: &str = "crypto/sigs/test-tool-release-audit.sign";
+    pub const TEST_TOOL_BLOCK_POLICY: &str = "policies/test_tool_release_block.yaml";
+    pub const TEST_TOOL_BLOCK_POLICY_SIG: &str = "crypto/sigs/test-tool-release-block.sign";
 }
 
 const TEST_TOOL_PIN: &str = "/sys/fs/bpf/test_tool_pin";
 const TEST_PROG_NAME: &str = "test_seabee";
 
-pub fn start_test_tool() -> Result<Child> {
+pub fn start_test_tool(level: SecurityLevel) -> Result<Child> {
     // add key
     Command::new(SEABEECTL_EXE)
         .args(["add-key", "-t", &utils::str_to_abs_path_str(RSA_PUB)?])
         .stdout(std::process::Stdio::null())
         .status()?;
 
+    // choose which policy to use
+    let (policy_file, policy_sig) = match level {
+        SecurityLevel::allow | SecurityLevel::audit => (
+            test_tool_config::TEST_TOOL_AUDIT_POLICY,
+            test_tool_config::TEST_TOOL_AUDIT_POLICY_SIG,
+        ),
+        SecurityLevel::block => (
+            test_tool_config::TEST_TOOL_BLOCK_POLICY,
+            test_tool_config::TEST_TOOL_BLOCK_POLICY_SIG,
+        ),
+    };
+
     // add policy
     Command::new(SEABEECTL_EXE)
         .args([
             "update",
             "-t",
-            &utils::str_to_abs_path_str(test_tool_config::TEST_TOOL_POLICY)?,
+            &utils::str_to_abs_path_str(policy_file)?,
             "-s",
-            &utils::str_to_abs_path_str(test_tool_config::TEST_TOOL_POLICY_SIG)?,
+            &utils::str_to_abs_path_str(policy_sig)?,
         ])
         .stdout(std::process::Stdio::null())
         .status()?;
@@ -61,6 +88,10 @@ pub fn start_test_tool() -> Result<Child> {
         }
         std::thread::sleep(std::time::Duration::from_secs(1))
     }
+    TEST_TOOL_PID
+        .get_or_init(|| AtomicU32::new(0))
+        .store(child.id(), Ordering::SeqCst);
+
     Ok(child)
 }
 
@@ -71,13 +102,27 @@ pub fn stop_test_tool(child: Child) -> Result<()> {
         return Err(anyhow!("Failed to send SIGINT to test tool"));
     }
 
-    // cleanup seabee
+    // remove policy
     Command::new(SEABEECTL_EXE)
-        .args(["clean", "policy"])
+        .args([
+            "remove",
+            "-t",
+            &utils::str_to_abs_path_str(REMOVE_TEST_TOOL_POLICY)?,
+            "-s",
+            &utils::str_to_abs_path_str(REMOVE_TEST_TOOL_POLICY_SIG)?,
+        ])
         .stdout(std::process::Stdio::null())
         .status()?;
+
+    // remove key
     Command::new(SEABEECTL_EXE)
-        .args(["clean", "keys"])
+        .args([
+            "remove-key",
+            "-t",
+            &utils::str_to_abs_path_str(RSA_PUB)?,
+            "-s",
+            &utils::str_to_abs_path_str(RSA_PUB_ROOT_SIG)?,
+        ])
         .stdout(std::process::Stdio::null())
         .status()?;
 
@@ -128,25 +173,55 @@ fn deny_map_access() -> Result<(), Failed> {
 
 /// Check that a null/0 signal can be sent to the process
 fn allow_signal_null() -> Result<(), Failed> {
-    test_utils::try_kill(0, *TEST_TOOL_PID.get().unwrap(), true)
+    test_utils::try_kill(0, TEST_TOOL_PID.get().unwrap().load(Ordering::SeqCst), true)
 }
 
 // /Check that a an allowed signal is allowed
 fn allow_signal_winch() -> Result<(), Failed> {
-    test_utils::try_kill(libc::SIGWINCH, *TEST_TOOL_PID.get().unwrap(), true)
+    test_utils::try_kill(
+        libc::SIGWINCH,
+        TEST_TOOL_PID.get().unwrap().load(Ordering::SeqCst),
+        true,
+    )
 }
 
 /// Check that a blocked signal is blocked
 fn deny_sigkill() -> Result<(), Failed> {
-    test_utils::try_kill(libc::SIGKILL, *TEST_TOOL_PID.get().unwrap(), false)
+    test_utils::try_kill(
+        libc::SIGKILL,
+        TEST_TOOL_PID.get().unwrap().load(Ordering::SeqCst),
+        false,
+    )
 }
 
-pub fn tests() -> Vec<Trial> {
+/// Check that ptrace is properly blocked
+fn deny_ptrace() -> Result<(), Failed> {
+    test_utils::try_ptrace_attach(TEST_TOOL_PID.get().unwrap().load(Ordering::SeqCst), false)
+}
+
+/// Check that ptrace can be allowed as well
+fn allow_ptrace() -> Result<(), Failed> {
+    test_utils::try_ptrace_attach(TEST_TOOL_PID.get().unwrap().load(Ordering::SeqCst), true)
+}
+
+fn block_tests() -> Vec<Trial> {
     vec![
         create_test!(deny_map_access),
         create_test!(deny_remove_pin),
         create_test!(allow_signal_null),
         create_test!(allow_signal_winch),
         create_test!(deny_sigkill),
+        create_test!(deny_ptrace),
     ]
+}
+
+fn audit_tests() -> Vec<Trial> {
+    vec![create_test!(allow_ptrace)]
+}
+
+pub fn get_tests(level: SecurityLevel) -> Vec<Trial> {
+    match level {
+        SecurityLevel::allow | SecurityLevel::audit => audit_tests(),
+        SecurityLevel::block => block_tests(),
+    }
 }

--- a/tests/src/security/ptrace.rs
+++ b/tests/src/security/ptrace.rs
@@ -8,7 +8,7 @@ use crate::{create_test, test_utils};
 /// Tests whether a ptrace can be attached to the current process
 fn security_ptrace_deny_attach() -> Result<(), Failed> {
     let pid = std::process::id();
-    test_utils::try_ptrace_attach(pid, false)
+    test_utils::try_ptrace(test_utils::PtraceOp::Attach, pid, false)
 }
 
 pub fn tests() -> Vec<Trial> {

--- a/tests/src/security/ptrace.rs
+++ b/tests/src/security/ptrace.rs
@@ -1,25 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to check the security of ptrace protections
-///
-/// TODO: Do we need to create a fork and ptrace our parent?
-///       Otherwise, it's unclear if `EPERM` is from SeaBee
 use libtest_mimic::{Failed, Trial};
 
-use crate::create_test;
+use crate::{create_test, test_utils};
 
 /// Tests whether a ptrace can be attached to the current process
 fn security_ptrace_deny_attach() -> Result<(), Failed> {
-    match nix::sys::ptrace::attach(nix::unistd::getpid()) {
-        Ok(_) => Err("Was able to ptrace attach to process".into()),
-        Err(err) => {
-            if err != nix::Error::EPERM {
-                Err(format!("Ptrace attach gave unexpected error: {err}").into())
-            } else {
-                Ok(())
-            }
-        }
-    }
+    let pid = std::process::id();
+    test_utils::try_ptrace_attach(pid, false)
 }
 
 pub fn tests() -> Vec<Trial> {

--- a/tests/src/test_utils.rs
+++ b/tests/src/test_utils.rs
@@ -1,17 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
 use libtest_mimic::Failed;
 
 /// Attempts to run `kill` with specified arguments and return code
 pub fn try_kill(signal: i32, pid: u32, expect_success: bool) -> Result<(), Failed> {
     let res = unsafe { libc::kill(pid as i32, signal) };
     if res == 0 && !expect_success {
-        Err(format!("Signal {signal:?} should not have succeeded, return: {res}").into())
+        Err(
+            format!("Signal {signal:?} should not have succeeded on pid {pid}, return: {res}")
+                .into(),
+        )
     } else if res != 0 && expect_success {
         Err(format!(
-            "Signal {signal:?} should not have failed: {}",
+            "Signal {signal:?} should not have failed on pid {pid}: {}",
             std::io::Error::last_os_error()
         )
         .into())
     } else {
         Ok(())
     }
+}
+
+/// Attempts PTRACE_ATTACH on target pid
+pub fn try_ptrace_attach(target_pid: u32, expect_success: bool) -> Result<(), Failed> {
+    let pid = nix::unistd::Pid::from_raw(target_pid as i32);
+    // try attach and then continue
+    match nix::sys::ptrace::attach(pid) {
+        Ok(_) => {
+            nix::sys::wait::waitpid(pid, None)
+                .map_err(|e| format!("failed waitpid on {pid}: {e}"))?;
+            nix::sys::ptrace::cont(pid, None)
+                .map_err(|e| format!("failed to continue process {pid}: {e}"))?;
+            if !expect_success {
+                return Err(format!("Failed to block ptrace on pid {target_pid}").into());
+            }
+        }
+        Err(e) => {
+            if expect_success {
+                return Err(format!("Failed to ptrace pid {target_pid}, error: {e:?}").into());
+            }
+            // check that the correct error was obtained
+            if e != nix::Error::EPERM {
+                return Err(format!("Ptrace attach gave unexpected error: {e}").into());
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/test_seabee.service
+++ b/tests/test_seabee.service
@@ -3,5 +3,5 @@ Description=SeaBee Service
 
 [Service]
 Type=exec
-ExecStart=/usr/sbin/seabee --sigint allow
+ExecStart=/usr/sbin/seabee --sigint allow --log-level debug
 KillSignal=SIGINT


### PR DESCRIPTION
Allows SeaBee policies to block ptrace to a processes in scope