### PR TITLE
46 detect stale pipx venv before checking poetry/asciinema version

### DIFF
--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -29,12 +29,23 @@ version_greater_equal() {
   printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
 }
 
+# detect a stale pipx venv left behind by a system Python upgrade
+PIPX_REINSTALLED=0
+pipx_venv_check() {
+  if [ "$PIPX_REINSTALLED" -eq 0 ] && command -v "$1" &>/dev/null && ! "$1" --version &>/dev/null; then
+    printf "%s has a stale pipx venv (likely a Python version change); reinstalling\n" "$1"
+    pipx reinstall-all
+    PIPX_REINSTALLED=1
+  fi
+}
+
 python_check() {
   if ! command -v "$PYTHON" &>/dev/null || ! version_greater_equal "$($PYTHON --version | cut -d" " -f2)" $PYTHON_VERSION; then
     printf "Compatible Python version not detected\n"
     printf "Please install Python %s or newer\n" "$PYTHON_VERSION"
     exit 1
   fi
+  pipx_venv_check "$POETRY"
   if ! command -v "$POETRY" &>/dev/null || ! version_greater_equal "$($POETRY --version | cut -d" " -f3 | tr -d ')')" $POETRY_VERSION; then
     printf "Compatible version of Poetry not detected\n"
     pipx install --force poetry==$POETRY_VERSION
@@ -42,6 +53,7 @@ python_check() {
     # shellcheck disable=SC1091
     source "$HOME/.profile" && poetry completions bash >>~/.bash_completion
   fi
+  pipx_venv_check "$ASCIINEMA"
   if [ "$DOCKER" -eq 0 ] && ! command -v "$ASCIINEMA" &>/dev/null || ! version_greater_equal "$($ASCIINEMA --version | cut -d" " -f2)" $ASCIINEMA_VERSION; then
     printf "Compatible version of Asciinema not detected\n"
     pipx install --force asciinema==$ASCIINEMA_VERSION


### PR DESCRIPTION
Detects a pipx venv left broken by a system Python upgrade and reinstalls it before the poetry/asciinema version checks run.
Fixes https://github.com/NationalSecurityAgency/seabee/issues/46